### PR TITLE
Feature/add interview status logic

### DIFF
--- a/controllers/interviews.js
+++ b/controllers/interviews.js
@@ -91,34 +91,50 @@ const InterviewTrainingInvitation = async (
   );
 };
 
-const computeStatus = async (db, interviews) => {
+const getInterviewsWithStatus = async (db, filter = {}) => {
   const now = Date.now();
 
-  const updatedInterviews = interviews.map((interview) => {
+  const interviews = await await db
+    .model('Interview')
+    .find(filter)
+    .populate('student_id trainer_id', 'firstname lastname email')
+    .populate('program_id', 'school program_name degree semester')
+    .populate('event_id')
+    .lean();
+  const interviewsWithStatus = [];
+  let openInterviews = [];
+
+  for (const interview of interviews) {
     const { interview_date, event_id, isClosed } = interview;
 
-    if (isClosed || (interview_date && interview_date < now)) {
-      return { ...interview, status: 'Closed' };
+    if (isClosed) {
+      interviewsWithStatus.push({ ...interview, status: 'Closed' });
+      continue;
+    }
+
+    if (interview_date && interview_date < now) {
+      interviewsWithStatus.push({ ...interview, status: 'Passed' });
+      continue;
     }
 
     if (event_id?.start) {
-      return event_id.start < now
-        ? { ...interview, status: 'Trained' }
-        : { ...interview, status: 'Scheduled' };
+      interviewsWithStatus.push({
+        ...interview,
+        status: event_id.start < now ? 'Trained' : 'Scheduled'
+      });
+      continue;
     }
 
-    return { ...interview, status: 'Open' };
-  });
+    // If none of the above, skip adding to interviewsWithStatus
+    openInterviews.push(interview);
+  }
 
   // Gather student IDs from 'Open' interviews
   const openStudentIds = new Set(
-    updatedInterviews
-      .filter((i) => i.status === 'Open')
-      .map((i) => i?.student_id?._id?.toString())
-      .filter(Boolean)
+    openInterviews.map((i) => i?.student_id?._id?.toString()).filter(Boolean)
   );
 
-  if (openStudentIds.size === 0) return updatedInterviews;
+  // Get trained student IDs with open interviews
   const trainedStudentIds = (
     await db
       .model('Interview')
@@ -129,29 +145,19 @@ const computeStatus = async (db, interviews) => {
       .distinct('student_id')
   ).map((id) => id.toString());
 
-  // Update 'Open' statuses to 'Not Needed' if matched
-  return updatedInterviews.map((interview) => {
-    if (interview.status !== 'Open') return interview;
-
+  openInterviews = openInterviews.map((interview) => {
     const studentId = interview?.student_id?._id?.toString();
     if (studentId && trainedStudentIds.includes(studentId)) {
       return { ...interview, status: 'N/A' };
     }
-
-    return interview;
+    return { ...interview, status: 'Open' };
   });
+
+  return [...openInterviews, ...interviewsWithStatus];
 };
 
 const getAllInterviews = asyncHandler(async (req, res) => {
-  let interviews = await req.db
-    .model('Interview')
-    .find()
-    .populate('student_id trainer_id', 'firstname lastname email')
-    .populate('program_id', 'school program_name degree semester')
-    .populate('event_id')
-    .lean();
-
-  interviews = await computeStatus(req.db, interviews);
+  let interviews = await getInterviewsWithStatus(req.db, {});
   res.status(200).send({ success: true, data: interviews });
 });
 

--- a/controllers/interviews.js
+++ b/controllers/interviews.js
@@ -105,7 +105,7 @@ const addInterviewStatus = async (db, interviews) => {
     }
 
     if (interview_date && interview_date < now) {
-      interviewsWithStatus.push({ ...interview, status: 'Passed' });
+      interviewsWithStatus.push({ ...interview, status: 'Interviewed' });
       continue;
     }
 

--- a/controllers/interviews.js
+++ b/controllers/interviews.js
@@ -95,9 +95,9 @@ const computeStatus = async (db, interviews) => {
   const now = Date.now();
 
   const updatedInterviews = interviews.map((interview) => {
-    const { interview_date, event_id } = interview;
+    const { interview_date, event_id, isClosed } = interview;
 
-    if (interview_date && interview_date < now) {
+    if (isClosed || (interview_date && interview_date < now)) {
       return { ...interview, status: 'Closed' };
     }
 
@@ -801,9 +801,10 @@ const createInterview = asyncHandler(async (req, res) => {
 });
 
 const getAllOpenInterviews = asyncHandler(async (req, res) => {
+  const now = Date.now();
   const interviews = await req.db
     .model('Interview')
-    .find({ isClosed: false })
+    .find({ isClosed: false, interview_date: { $gte: now } })
     .populate('student_id trainer_id', 'firstname lastname email')
     .populate('program_id', 'school program_name degree semester')
     .populate('event_id')

--- a/controllers/interviews.js
+++ b/controllers/interviews.js
@@ -804,7 +804,7 @@ const getAllOpenInterviews = asyncHandler(async (req, res) => {
   const now = Date.now();
   const interviews = await req.db
     .model('Interview')
-    .find({ isClosed: false, interview_date: { $gte: now } })
+    .find({ isClosed: false, interview_date: { $lte: now } })
     .populate('student_id trainer_id', 'firstname lastname email')
     .populate('program_id', 'school program_name degree semester')
     .populate('event_id')
@@ -816,7 +816,9 @@ const getAllOpenInterviews = asyncHandler(async (req, res) => {
 const getInterviewsByProgramId = asyncHandler(async (req, res) => {
   const { programId } = req.params;
   if (!programId) {
-    return res.status(400).send({ success: false, message: 'Program ID is required' });
+    return res
+      .status(400)
+      .send({ success: false, message: 'Program ID is required' });
   }
 
   try {
@@ -824,13 +826,15 @@ const getInterviewsByProgramId = asyncHandler(async (req, res) => {
       .model('Interview')
       .find({ program_id: programId })
       .populate('student_id', 'firstname lastname email')
-      .populate('trainer_id', 'firstname lastname email')  // This will populate an array of trainers
+      .populate('trainer_id', 'firstname lastname email') // This will populate an array of trainers
       .populate('program_id', 'school program_name degree semester')
       .populate('event_id')
       .populate('thread_id')
       .lean();
 
-    res.status(200).send({ success: true, data: interviews, count: interviews.length });
+    res
+      .status(200)
+      .send({ success: true, data: interviews, count: interviews.length });
   } catch (error) {
     res.status(500).send({ success: false, message: error.message });
   }
@@ -839,7 +843,9 @@ const getInterviewsByProgramId = asyncHandler(async (req, res) => {
 const getInterviewsByStudentId = asyncHandler(async (req, res) => {
   const { studentId } = req.params;
   if (!studentId) {
-    return res.status(400).send({ success: false, message: 'Student ID is required' });
+    return res
+      .status(400)
+      .send({ success: false, message: 'Student ID is required' });
   }
 
   try {
@@ -847,13 +853,15 @@ const getInterviewsByStudentId = asyncHandler(async (req, res) => {
       .model('Interview')
       .find({ student_id: studentId })
       .populate('student_id', 'firstname lastname email')
-      .populate('trainer_id', 'firstname lastname email')  // This will populate an array of trainers
+      .populate('trainer_id', 'firstname lastname email') // This will populate an array of trainers
       .populate('program_id', 'school program_name degree semester')
       .populate('event_id')
       .populate('thread_id')
       .lean();
 
-    res.status(200).send({ success: true, data: interviews, count: interviews.length });
+    res
+      .status(200)
+      .send({ success: true, data: interviews, count: interviews.length });
   } catch (error) {
     res.status(500).send({ success: false, message: error.message });
   }


### PR DESCRIPTION
This pull request introduces a new utility function, `addInterviewStatus`, to centralize and standardize the logic for determining the status of interviews. The function is integrated into several existing endpoints to enhance data consistency and reduce code duplication.

The interview thread status is no longer stored persistently in the database; it is now computed at runtime.

**TODO**:
- [ ]  drop existing status fields in the collection to avoid confusion.
- [ ] Add i18 translation to statuses

### Major Changes:

#### New Utility Function:
* Added `addInterviewStatus` function in `controllers/interviews.js` to calculate and append a `status` field to interview records based on various conditions, such as interview date, event status, and student training status.

#### Integration of `addInterviewStatus`:
* Integrated `addInterviewStatus` into `getAllInterviews` and `getMyInterview` to process interview statuses before sending the response. 
* Modified `getInterview` to apply `addInterviewStatus` for a single interview record, ensuring consistent status calculation.

Preview: 
![image](https://github.com/user-attachments/assets/3d1fc9f9-5028-4e63-8cca-7b8716b7ebd7)
* N/A: Already trained for other interviews
* Passed: Official interview date has passed, but interview thread not yet closed. (`isClosed` is false) -> open for better naming